### PR TITLE
feat: ignore python cache dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 civitai/
 models/
-
+__pycache__/


### PR DESCRIPTION
Not sure if it only happens on my device or is a common phenomenon, but those cache files can be ignored.
![image](https://github.com/Davemane42/ComfyUI_Dave_CustomNode/assets/20502130/d15271ae-412c-462e-970b-ea1da513adc7)
